### PR TITLE
feat: add XR status links auto-generation feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     ]
   },
   "bin": {
-    "ingestor": "./bin/ingestor",
-    "backstage-export": "./bin/backstage-export"
+    "backstage-export": "./bin/backstage-export",
+    "ingestor": "./bin/ingestor"
   },
   "scripts": {
     "start": "backstage-cli package start",

--- a/src/entity-providers/KubernetesEntityProvider.test.ts
+++ b/src/entity-providers/KubernetesEntityProvider.test.ts
@@ -1,0 +1,272 @@
+import { KubernetesEntityProvider } from './KubernetesEntityProvider';
+import { BackstageLink } from '../interfaces';
+
+describe('KubernetesEntityProvider', () => {
+  describe('generateLinksFromXRStatus', () => {
+    let provider: any;
+
+    beforeEach(() => {
+      // Create a minimal mock provider to test the private method
+      provider = new KubernetesEntityProvider(
+        {} as any,
+        { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+        { getOptionalString: () => 'terasky.backstage.io' } as any,
+        {} as any,
+      );
+    });
+
+    // Access private method for testing
+    const callGenerateLinksFromXRStatus = (xr: any): BackstageLink[] => {
+      return (provider as any).generateLinksFromXRStatus(xr);
+    };
+
+    it('should return empty array when status is missing', () => {
+      const xr = { metadata: { name: 'test-xr' } };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toEqual([]);
+    });
+
+    it('should extract domain from status', () => {
+      const xr = {
+        status: {
+          domain: 'example.com'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://example.com',
+        title: 'Service Domain',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should create DNS query link for FQDN', () => {
+      const xr = {
+        status: {
+          fqdn: 'service.example.com'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://dns.google/query?name=service.example.com&type=ALL',
+        title: 'DNS Query (Google)',
+        icon: 'DNS'
+      });
+    });
+
+    it('should extract URL from status', () => {
+      const xr = {
+        status: {
+          url: 'https://api.example.com'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://api.example.com',
+        title: 'Service URL',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should extract ingress host from status', () => {
+      const xr = {
+        status: {
+          ingress: {
+            host: 'app.example.com'
+          }
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://app.example.com',
+        title: 'Ingress URL',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle string endpoint', () => {
+      const xr = {
+        status: {
+          endpoint: 'service.local:8080'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://service.local:8080',
+        title: 'Endpoint',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle endpoint with http prefix', () => {
+      const xr = {
+        status: {
+          endpoint: 'http://service.local:8080'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'http://service.local:8080',
+        title: 'Endpoint',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle object endpoint', () => {
+      const xr = {
+        status: {
+          endpoint: {
+            url: 'https://custom.endpoint.com',
+            title: 'Custom Endpoint',
+            icon: 'Cloud'
+          }
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://custom.endpoint.com',
+        title: 'Custom Endpoint',
+        icon: 'Cloud'
+      });
+    });
+
+    it('should handle endpoints array with strings', () => {
+      const xr = {
+        status: {
+          endpoints: [
+            'endpoint1.com',
+            'http://endpoint2.com'
+          ]
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://endpoint1.com',
+        title: 'Endpoint 1',
+        icon: 'WebAsset'
+      });
+      expect(links).toContainEqual({
+        url: 'http://endpoint2.com',
+        title: 'Endpoint 2',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle endpoints array with objects', () => {
+      const xr = {
+        status: {
+          endpoints: [
+            { url: 'https://api.example.com', title: 'API' },
+            { url: 'https://web.example.com', name: 'Web UI' }
+          ]
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://api.example.com',
+        title: 'API',
+        icon: 'WebAsset'
+      });
+      expect(links).toContainEqual({
+        url: 'https://web.example.com',
+        title: 'Web UI',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle URLs array', () => {
+      const xr = {
+        status: {
+          urls: [
+            'https://url1.com',
+            { href: 'https://url2.com', title: 'Second URL' }
+          ]
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://url1.com',
+        title: 'URL 1',
+        icon: 'WebAsset'
+      });
+      expect(links).toContainEqual({
+        url: 'https://url2.com',
+        title: 'Second URL',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle address field with domain', () => {
+      const xr = {
+        status: {
+          address: 'db.internal.example.com'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://db.internal.example.com',
+        title: 'Service Address',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should skip address field without domain', () => {
+      const xr = {
+        status: {
+          address: '192-168-1-1'  // No dots, not a domain
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toHaveLength(0);
+    });
+
+    it('should handle hostname field', () => {
+      const xr = {
+        status: {
+          hostname: 'service.cluster.local'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://service.cluster.local',
+        title: 'Service Hostname',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should handle externalURL field', () => {
+      const xr = {
+        status: {
+          externalURL: 'https://monitoring.example.com/dashboard'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toContainEqual({
+        url: 'https://monitoring.example.com/dashboard',
+        title: 'External URL',
+        icon: 'WebAsset'
+      });
+    });
+
+    it('should extract multiple fields from status', () => {
+      const xr = {
+        status: {
+          domain: 'example.com',
+          fqdn: 'service.example.com',
+          url: 'https://api.example.com',
+          endpoints: ['endpoint1.com'],
+          externalURL: 'https://external.example.com'
+        }
+      };
+      const links = callGenerateLinksFromXRStatus(xr);
+      expect(links).toHaveLength(5);
+      expect(links.map(l => l.title)).toEqual([
+        'Service Domain',
+        'DNS Query (Google)',
+        'Service URL',
+        'Endpoint 1',
+        'External URL'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements automatic link generation from XR status fields, making service URLs immediately accessible in Backstage's Links section.

## Closes #2

## What's Changed

### ✨ New Feature
- Added `generateLinksFromXRStatus()` method to automatically extract URLs from XR status fields
- Integrated status link generation into the component entity building process
- Links from status are merged with existing annotation links

### 🔍 Supported Status Fields

#### Single URL Fields
- `status.domain` → Service Domain link
- `status.fqdn` → Google DNS Query link
- `status.url` → Service URL link
- `status.endpoint` → Endpoint link (string or object)
- `status.ingress.host` → Ingress URL link
- `status.address` → Service Address link (if domain-like)
- `status.hostname` → Service Hostname link
- `status.externalURL` → External URL link

#### Array Fields
- `status.endpoints[]` → Multiple endpoint links
- `status.urls[]` → Multiple URL links

### 🧪 Testing
- Added comprehensive unit tests covering all status field patterns
- Tests verify proper URL formatting and link generation
- Tests ensure arrays and objects are handled correctly

## How It Works

1. When processing XR entities, the system now checks the XR's status field
2. Common URL patterns are automatically detected and extracted
3. Links are generated with appropriate titles and icons
4. Status links are merged with any existing annotation-based links
5. The resulting links appear in Backstage's Links section for the entity

## Benefits

✅ **Automatic Discovery** - No manual link annotations needed
✅ **Works for All XRs** - Any XR with status URLs benefits automatically
✅ **Smart Detection** - Handles various field formats (strings, objects, arrays)
✅ **DNS Integration** - FQDN fields generate useful DNS query links
✅ **Backwards Compatible** - Works alongside existing link annotations

## Example

An XR with this status:
```yaml
status:
  domain: myapp.example.com
  endpoints:
    - https://api.myapp.example.com
    - https://admin.myapp.example.com
```

Will automatically generate these links in Backstage:
- Service Domain → https://myapp.example.com
- Endpoint 1 → https://api.myapp.example.com
- Endpoint 2 → https://admin.myapp.example.com

## Testing

Run the tests:
```bash
yarn test KubernetesEntityProvider.test
```