### PR TITLE
fix: resolve templateDir relative paths and standardize config

### DIFF
--- a/src/backstage-export/cli/backstage-export-cli.ts
+++ b/src/backstage-export/cli/backstage-export-cli.ts
@@ -142,11 +142,14 @@ async function exportEntities(entities: Entity[], options: ExportOptions): Promi
           : JSON.stringify(entity, null, 2);
 
         fs.writeFileSync(filepath, content);
+        const relativePath = path.relative(outputDir, filepath);
+        console.log(`  ✓ ${relativePath}`);
+
         manifestEntries.push({
           kind: entity.kind,
           name: entity.metadata.name,
           namespace: entity.metadata.namespace,
-          file: path.relative(outputDir, filepath),
+          file: relativePath,
         });
       }
     }
@@ -160,6 +163,8 @@ async function exportEntities(entities: Entity[], options: ExportOptions): Promi
         : JSON.stringify(entity, null, 2);
 
       fs.writeFileSync(filepath, content);
+      console.log(`  ✓ ${filename}`);
+
       manifestEntries.push({
         kind: entity.kind,
         name: entity.metadata.name,

--- a/src/backstage-plugin/types.ts
+++ b/src/backstage-plugin/types.ts
@@ -12,10 +12,8 @@ export interface IngestorConfig {
     tags?: string[];
   };
   filters?: ResourceFilter[];
-  transform?: {
-    templateDir?: string;
-    useXRDTransform?: boolean;
-  };
+  // Note: templateDir is configured at ingestor.crossplane.xrds.templateDir
+  // (used by both CLI and Backstage plugin runtime)
 }
 
 export interface KubernetesClusterConfig {

--- a/src/xrd-transform/lib/transform.ts
+++ b/src/xrd-transform/lib/transform.ts
@@ -43,6 +43,10 @@ export class XRDTransformer {
     this.helpers = createHelpers();
     this.handlebars = Handlebars.create();
 
+    // Debug: Log template directory
+    console.log(`[XRDTransformer] Template directory: ${this.templateDir}`);
+    console.log(`[XRDTransformer] Template directory exists: ${fs.existsSync(this.templateDir)}`);
+
     // Register helpers with Handlebars
     this.registerHelpers();
   }

--- a/src/xrd-transform/lib/transform.ts
+++ b/src/xrd-transform/lib/transform.ts
@@ -36,16 +36,20 @@ export class XRDTransformer {
   private templateDir: string;
   private templateNameOverride?: string;
   private helpers: ReturnType<typeof createHelpers>;
+  private verbose: boolean;
 
   constructor(options?: TransformOptions) {
     this.templateDir = options?.templateDir || DEFAULT_TEMPLATE_DIR;
     this.templateNameOverride = options?.templateName;
+    this.verbose = options?.verbose ?? false;
     this.helpers = createHelpers();
     this.handlebars = Handlebars.create();
 
-    // Debug: Log template directory
-    console.log(`[XRDTransformer] Template directory: ${this.templateDir}`);
-    console.log(`[XRDTransformer] Template directory exists: ${fs.existsSync(this.templateDir)}`);
+    // Debug: Log template directory (only in verbose mode)
+    if (this.verbose) {
+      console.log(`[XRDTransformer] Template directory: ${this.templateDir}`);
+      console.log(`[XRDTransformer] Template directory exists: ${fs.existsSync(this.templateDir)}`);
+    }
 
     // Register helpers with Handlebars
     this.registerHelpers();


### PR DESCRIPTION
## Summary

Fix critical bug where custom ingestor templates fail to load due to incorrect path resolution.

## Problem

The ingestor plugin was failing to load custom templates configured at `ingestor.crossplane.xrds.templateDir` because:

1. **Relative paths don't work**: Config value `./ingestor-templates` was resolved from the **backend working directory** (`packages/backend`), not the app-portal root
2. **Result**: Templates not found, plugin falls back to npm package built-in templates
3. **Impact**: Custom templates (including labels, custom fields) are ignored

## Root Cause Analysis

### Two Config Paths (Confusion!)

There were **two different config paths** defined:
- `ingestor.transform.templateDir` - Defined in TypeScript types but **never actually used**
- `ingestor.crossplane.xrds.templateDir` - Actually used by CLI and documented

**Solution**: Standardized on `ingestor.crossplane.xrds.templateDir` (the one that's actually used and documented)

### Path Resolution Issue

```typescript
// BEFORE (broken)
const templateDir = this.config.getOptionalString('ingestor.crossplane.xrds.templateDir');
this.transformer = new XRDTransformer(templateDir ? { templateDir } : undefined);
// Problem: './ingestor-templates' resolves from backend CWD (packages/backend/)
// Result: /app-portal/packages/backend/ingestor-templates ❌ (doesn't exist)
```

```typescript
// AFTER (fixed)
const templateDirConfig = this.config.getOptionalString('ingestor.crossplane.xrds.templateDir');
const appRoot = path.resolve(process.cwd(), '../..');
const templateDir = path.resolve(appRoot, templateDirConfig);
// Result: /app-portal/ingestor-templates ✅ (exists!)
```

## Changes

### 1. Fix Path Resolution
**File**: `src/backstage-plugin/entity-providers/XRDTemplateEntityProvider.ts`
- Resolve relative paths to absolute before passing to transformer
- Calculate app root as 2 levels up from backend working directory
- Add comprehensive debug logging

### 2. Remove Unused Config Type
**File**: `src/backstage-plugin/types.ts`
- Removed unused `transform?: { templateDir }` type definition
- Added comment documenting the correct config path
- Eliminates confusion between two config paths

### 3. Add Debug Logging
**File**: `src/xrd-transform/lib/transform.ts`
- Log template directory being used
- Log whether template directory exists
- Helps diagnose template loading issues

## Benefits

✅ **Custom templates now load correctly**
✅ **Relative paths work**: `./ingestor-templates` resolves properly
✅ **Absolute paths work**: `/full/path` passes through unchanged
✅ **Debug logging**: Easy to diagnose template issues
✅ **Consistent config**: One standard path used everywhere

## Testing

### Before Fix
```bash
# Templates not found
grep "Generated.*entities" logs/*.log
# Output: Generated 0 entities total ❌
```

### After Fix
```bash
# Templates load successfully
grep "Generated.*entities" logs/*.log
# Output: Generated 10 entities total ✅

# Verify custom templates used
grep "Template directory:" logs/*.log
# Output: Template directory: /app-portal/ingestor-templates ✅
```

### Test Custom Template Markers
```bash
# Add test marker to template
echo "testMarker: testValue" >> ingestor-templates/backstage/default.hbs

# Export and verify
./scripts/template-export.sh -o templates/test
grep "testMarker" templates/test/template-*.yaml
# Should find the marker ✅
```

## Breaking Changes

None - this is a bug fix that makes the documented config path actually work.

## Related

- Fixes template customization workflow from docs/template-customization.md
- Makes PR #56 (app-portal config correction) work properly
- Aligns with CLI behavior (which already uses this config path)

## Follow-up

After this is merged and published:
1. Publish new version (suggest v2.3.1 or v2.4.0)
2. Update app-portal to use published version
3. Verify PR #56 works with new plugin version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional verbose mode exposing template usage and export progress details at runtime.

* **Improvements**
  * Enhanced export progress logging with precise relative paths for created files.
  * Transformation logs now include entity metadata labels for clearer visibility.
  * Manifest entries now consistently reference the same relative paths shown in logs.

* **Configuration**
  * Revised template directory configuration location and runtime resolution with clearer logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->